### PR TITLE
Version 1.3.3.7 Testing breakthrough

### DIFF
--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -153,10 +153,15 @@ func TestNewCheckHandler(t *testing.T) {
 			Type: mocks.ResponseTypeSend,
 		}
 
+		expectedStorage := map[string]any{
+			models.SESSION_ID: sessionId,
+		}
+
 		handlerErr := NewCheckHandler(teleCtx, stateCtx)
 
 		assertHandlerError(t, false, errEmpty, handlerErr)
 		assertHandlerResponse(t, expectedResponse, &response)
 		assertState(t, models.StateWaitForCheckName, stateCtx)
+		assertStorage(t, &expectedStorage, fsmStorage)
 	})
 }

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -109,3 +109,30 @@ func TestHelloHandler(t *testing.T) {
 	assertHandlerError(t, false, errEmpty, handlerErr)
 	assertHandlerResponse(t, &expextedResponse, &response)
 }
+
+func TestNewCheckHandler(t *testing.T) {
+	t.Run("command-call from default state (no err)", func(t *testing.T) {
+		response := mocks.HandlerResponse{}
+		bot := mocks.NewMockBot(&response)
+		botStorage := mocks.NewMockStorage()
+		var sessionId int64 = 1
+		botStorage.Set(models.SESSION_ID, sessionId)
+		fsmStorage := mocks.NewMockStorage()
+
+		update := makeUpdateWithMessageText("/newcheck")
+
+		teleCtx := mocks.NewMockContext(bot, update, botStorage, &response)
+		stateCtx := mocks.NewMockFsmContext(fsmStorage, models.StateDefault)
+
+		expectedResponse := &mocks.HandlerResponse{
+			Text: "Хорошо, как назовем новый чек?👀",
+			Type: mocks.ResponseTypeSend,
+		}
+
+		handlerErr := NewCheckHandler(teleCtx, stateCtx)
+
+		assertHandlerError(t, false, errEmpty, handlerErr)
+		assertHandlerResponse(t, expectedResponse, &response)
+		assertState(t, models.StateWaitForCheckName, stateCtx)
+	})
+}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -3,6 +3,7 @@ package handlers
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/Tesorp1X/chipi-bot/mocks"
@@ -63,6 +64,29 @@ func assertState(t testing.TB, expected fsm.State, fsmCtx *mocks.MockFsmContext)
 
 	if expected != gotState {
 		t.Fatalf("expected state: %s, but got insted: %s", expected, gotState)
+	}
+}
+
+// Fails a test if storage is missing any (key, value) tuple from expected,
+// or if expected and got values are not deeply equal (must have the same type).
+func assertStorage(t testing.TB, expected *map[string]any, storage *mocks.MockStorage) {
+	t.Helper()
+	for k, v := range *expected {
+		storageVal := storage.Get(k)
+		if storageVal == nil {
+			t.Fatalf("in storage expected (key, value): (%s, %v), but instead got nil", k, v)
+		}
+
+		expectedReflectValue := reflect.ValueOf(v)
+		gotReflectValue := reflect.ValueOf(storageVal)
+
+		if expectedReflectValue.Type() != gotReflectValue.Type() {
+			t.Fatalf("in storage for key %s expected value type of %v, but insted got %v", k, expectedReflectValue.Type(), gotReflectValue.Type())
+		}
+
+		if !reflect.DeepEqual(expectedReflectValue, gotReflectValue) {
+			t.Fatalf("in storage for for key %s expected value %v, but instaed got %v", k, expectedReflectValue, gotReflectValue)
+		}
 	}
 }
 

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Tesorp1X/chipi-bot/mocks"
 	"github.com/Tesorp1X/chipi-bot/models"
+	"github.com/vitaliy-ukiru/fsm-telebot/v2"
 	tele "gopkg.in/telebot.v4"
 )
 
@@ -52,6 +53,19 @@ func assertHandlerResponse(t testing.TB, expected, got *mocks.HandlerResponse) {
 
 }
 
+// Fails a test if fsmCtx's state doesn't equal to expected.
+func assertState(t testing.TB, expected fsm.State, fsmCtx *mocks.MockFsmContext) {
+	t.Helper()
+	gotState, err := fsmCtx.State(context.Background())
+	if err != nil {
+		t.Fatalf("assertState error: %v", err)
+	}
+
+	if expected != gotState {
+		t.Fatalf("expected state: %s, but got insted: %s", expected, gotState)
+	}
+}
+
 // Returns an update with non-nil Message field. User has ID 1, Name: Test Test and username: @test123.
 func makeUpdateWithMessageText(text string) tele.Update {
 	return tele.Update{
@@ -73,12 +87,13 @@ func makeUpdateWithMessageText(text string) tele.Update {
 func TestHelloHandler(t *testing.T) {
 	response := mocks.HandlerResponse{}
 	bot := mocks.NewMockBot(&response)
-	storage := mocks.NewMockStorage()
+	botStorage := mocks.NewMockStorage()
+	fsmStorage := mocks.NewMockStorage()
 
 	update := makeUpdateWithMessageText("hello")
 
-	teleCtx := mocks.NewMockContext(bot, update, storage, &response)
-	stateCtx := mocks.NewMockFsmContext(storage, models.StateDefault)
+	teleCtx := mocks.NewMockContext(bot, update, botStorage, &response)
+	stateCtx := mocks.NewMockFsmContext(fsmStorage, models.StateDefault)
 
 	expextedResponse := mocks.HandlerResponse{
 		Text: "Hello, 1",

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -1,0 +1,96 @@
+package handlers
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/Tesorp1X/chipi-bot/mocks"
+	"github.com/Tesorp1X/chipi-bot/models"
+	tele "gopkg.in/telebot.v4"
+)
+
+var errEmpty = errors.New("")
+
+func assertHandlerError(t testing.TB, wantErr bool, expexted, got error) {
+	t.Helper()
+	if !wantErr && got == nil {
+		return
+	}
+
+	if !wantErr && got != nil {
+		t.Fatalf("didn't expect an error but got: %v", got)
+	}
+
+	if wantErr && got == nil {
+		t.Fatalf("expected an error: '%v' but got none", expexted)
+	}
+
+	if expexted != got {
+		t.Fatalf("expected an error: '%v'', but instead got: '%v'", expexted, got)
+	}
+}
+
+func assertHandlerResponse(t testing.TB, expected, got *mocks.HandlerResponse) {
+	t.Helper()
+	if !got.IsResponseTextEqualsTo(expected.Text) {
+		t.Fatalf("expected response text: '%s', but got: '%s'", expected.Text, got.Text)
+	}
+
+	if !got.IsResponseTypeEqualsTo(expected.Type) {
+		t.Fatalf("expected response type: '%d', but got: '%d'", expected.Type, got.Type)
+	}
+
+	if expected.SendOptions != nil {
+		if ok, err := got.IsResponseReplyMarkUpEqualsTo(expected.SendOptions.ReplyMarkup); !ok {
+			if err != nil {
+				t.Fatalf("assertResponse error: %v", err)
+			}
+			t.Fatal("wrong reply markup")
+		}
+	}
+
+}
+
+// Returns an update with non-nil Message field. User has ID 1, Name: Test Test and username: @test123.
+func makeUpdateWithMessageText(text string) tele.Update {
+	return tele.Update{
+		ID: 1,
+		Message: &tele.Message{
+			ID:   1,
+			Text: text,
+			Sender: &tele.User{
+				ID:        1,
+				FirstName: "Test",
+				LastName:  "Test",
+				Username:  "test123",
+			},
+		},
+	}
+
+}
+
+func TestHelloHandler(t *testing.T) {
+	response := mocks.HandlerResponse{}
+	bot := mocks.NewMockBot(&response)
+	storage := mocks.NewMockStorage()
+
+	update := makeUpdateWithMessageText("hello")
+
+	teleCtx := mocks.NewMockContext(bot, update, storage, &response)
+	stateCtx := mocks.NewMockFsmContext(storage, models.StateDefault)
+
+	expextedResponse := mocks.HandlerResponse{
+		Text: "Hello, 1",
+		Type: mocks.ResponseTypeSend,
+	}
+
+	if err := stateCtx.SetState(context.Background(), models.StateStart); err != nil {
+		t.Fatalf("couldn't change state to %s: %v", models.StateStart, err)
+	}
+
+	handlerErr := HelloHandler(teleCtx, stateCtx)
+
+	assertHandlerError(t, false, errEmpty, handlerErr)
+	assertHandlerResponse(t, &expextedResponse, &response)
+}

--- a/handlers/handlers_test.go
+++ b/handlers/handlers_test.go
@@ -84,7 +84,7 @@ func assertStorage(t testing.TB, expected *map[string]any, storage *mocks.MockSt
 			t.Fatalf("in storage for key %s expected value type of %v, but insted got %v", k, expectedReflectValue.Type(), gotReflectValue.Type())
 		}
 
-		if !reflect.DeepEqual(expectedReflectValue, gotReflectValue) {
+		if !reflect.DeepEqual(v, storageVal) {
 			t.Fatalf("in storage for for key %s expected value %v, but instaed got %v", k, expectedReflectValue, gotReflectValue)
 		}
 	}

--- a/mocks/bot_mock.go
+++ b/mocks/bot_mock.go
@@ -1,0 +1,488 @@
+package mocks
+
+import (
+	"errors"
+	"io"
+
+	tele "gopkg.in/telebot.v4"
+)
+
+// MockBotAPI implements the [tele.API] interface with no-op methods and zero values
+type MockBotAPI struct {
+	// Channel with responses from handler via bot instance or [tele.Context]
+	response *HandlerResponse
+}
+
+func NewMockBot(resp *HandlerResponse) *MockBotAPI {
+	return &MockBotAPI{
+		response: resp,
+	}
+}
+
+// Methods bellow the line are for testing
+// --------------------------------------------------------------------
+
+// Methods bellow the line are to satisfy the [tele.API] interface
+// --------------------------------------------------------------------
+func (m *MockBotAPI) Raw(method string, payload interface{}) ([]byte, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) Accept(query *tele.PreCheckoutQuery, errorMessage ...string) error {
+	return nil
+}
+
+func (m *MockBotAPI) AddStickerToSet(of tele.Recipient, name string, sticker tele.InputSticker) error {
+	return nil
+}
+
+func (m *MockBotAPI) AdminsOf(chat *tele.Chat) ([]tele.ChatMember, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) Answer(query *tele.Query, resp *tele.QueryResponse) error {
+	return nil
+}
+
+func (m *MockBotAPI) AnswerWebApp(query *tele.Query, r tele.Result) (*tele.WebAppMessage, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) ApproveJoinRequest(chat tele.Recipient, user *tele.User) error {
+	return nil
+}
+
+func (m *MockBotAPI) Ban(chat *tele.Chat, member *tele.ChatMember, revokeMessages ...bool) error {
+	return nil
+}
+
+func (m *MockBotAPI) BanSenderChat(chat *tele.Chat, sender tele.Recipient) error {
+	return nil
+}
+
+func (m *MockBotAPI) BusinessConnection(id string) (*tele.BusinessConnection, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) ChatByID(id int64) (*tele.Chat, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) ChatByUsername(name string) (*tele.Chat, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) ChatMemberOf(chat, user tele.Recipient) (*tele.ChatMember, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) Close() (bool, error) {
+	return false, nil
+}
+
+func (m *MockBotAPI) CloseGeneralTopic(chat *tele.Chat) error {
+	return nil
+}
+
+func (m *MockBotAPI) CloseTopic(chat *tele.Chat, topic *tele.Topic) error {
+	return nil
+}
+
+func (m *MockBotAPI) Commands(opts ...interface{}) ([]tele.Command, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) Copy(to tele.Recipient, msg tele.Editable, opts ...interface{}) (*tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) CopyMany(to tele.Recipient, msgs []tele.Editable, opts ...*tele.SendOptions) ([]tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) CreateInviteLink(chat tele.Recipient, link *tele.ChatInviteLink) (*tele.ChatInviteLink, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) CreateInvoiceLink(i tele.Invoice) (string, error) {
+	return "", nil
+}
+
+func (m *MockBotAPI) CreateStickerSet(of tele.Recipient, set *tele.StickerSet) error {
+	return nil
+}
+
+func (m *MockBotAPI) CreateTopic(chat *tele.Chat, topic *tele.Topic) (*tele.Topic, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) CustomEmojiStickers(ids []string) ([]tele.Sticker, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) DeclineJoinRequest(chat tele.Recipient, user *tele.User) error {
+	return nil
+}
+
+func (m *MockBotAPI) DefaultRights(forChannels bool) (*tele.Rights, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) Delete(msg tele.Editable) error {
+	return nil
+}
+
+func (m *MockBotAPI) DeleteCommands(opts ...interface{}) error {
+	return nil
+}
+
+func (m *MockBotAPI) DeleteGroupPhoto(chat *tele.Chat) error {
+	return nil
+}
+
+func (m *MockBotAPI) DeleteGroupStickerSet(chat *tele.Chat) error {
+	return nil
+}
+
+func (m *MockBotAPI) DeleteMany(msgs []tele.Editable) error {
+	return nil
+}
+
+func (m *MockBotAPI) DeleteSticker(sticker string) error {
+	return nil
+}
+
+func (m *MockBotAPI) DeleteStickerSet(name string) error {
+	return nil
+}
+
+func (m *MockBotAPI) DeleteTopic(chat *tele.Chat, topic *tele.Topic) error {
+	return nil
+}
+
+func (m *MockBotAPI) Download(file *tele.File, localFilename string) error {
+	return nil
+}
+
+func (m *MockBotAPI) Edit(msg tele.Editable, what interface{}, opts ...interface{}) (*tele.Message, error) {
+	text, ok := what.(string)
+	if !ok {
+		return nil, errors.New("expected what of type string")
+	}
+
+	m.response.Text = text
+	m.response.Type = ResponseTypeEdit
+	m.response.SendOptions = extractOptions(opts)
+
+	return nil, nil
+}
+
+func (m *MockBotAPI) EditCaption(msg tele.Editable, caption string, opts ...interface{}) (*tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) EditGeneralTopic(chat *tele.Chat, topic *tele.Topic) error {
+	return nil
+}
+
+func (m *MockBotAPI) EditInviteLink(chat tele.Recipient, link *tele.ChatInviteLink) (*tele.ChatInviteLink, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) EditMedia(msg tele.Editable, media tele.Inputtable, opts ...interface{}) (*tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) EditReplyMarkup(msg tele.Editable, markup *tele.ReplyMarkup) (*tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) EditTopic(chat *tele.Chat, topic *tele.Topic) error {
+	return nil
+}
+
+func (m *MockBotAPI) File(file *tele.File) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) FileByID(fileID string) (tele.File, error) {
+	return tele.File{}, nil
+}
+
+func (m *MockBotAPI) Forward(to tele.Recipient, msg tele.Editable, opts ...interface{}) (*tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) ForwardMany(to tele.Recipient, msgs []tele.Editable, opts ...*tele.SendOptions) ([]tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) GameScores(user tele.Recipient, msg tele.Editable) ([]tele.GameHighScore, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) HideGeneralTopic(chat *tele.Chat) error {
+	return nil
+}
+
+func (m *MockBotAPI) InviteLink(chat *tele.Chat) (string, error) {
+	return "", nil
+}
+
+func (m *MockBotAPI) Leave(chat tele.Recipient) error {
+	return nil
+}
+
+func (m *MockBotAPI) Len(chat *tele.Chat) (int, error) {
+	return 0, nil
+}
+
+func (m *MockBotAPI) Logout() (bool, error) {
+	return false, nil
+}
+
+func (m *MockBotAPI) MenuButton(chat *tele.User) (*tele.MenuButton, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) MyDescription(language string) (*tele.BotInfo, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) MyName(language string) (*tele.BotInfo, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) MyShortDescription(language string) (*tele.BotInfo, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) Notify(to tele.Recipient, action tele.ChatAction, threadID ...int) error {
+	return nil
+}
+
+func (m *MockBotAPI) Pin(msg tele.Editable, opts ...interface{}) error {
+	return nil
+}
+
+func (m *MockBotAPI) ProfilePhotosOf(user *tele.User) ([]tele.Photo, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) Promote(chat *tele.Chat, member *tele.ChatMember) error {
+	return nil
+}
+
+func (m *MockBotAPI) React(to tele.Recipient, msg tele.Editable, r tele.Reactions) error {
+	return nil
+}
+
+func (m *MockBotAPI) RefundStars(to tele.Recipient, chargeID string) error {
+	return nil
+}
+
+func (m *MockBotAPI) RemoveWebhook(dropPending ...bool) error {
+	return nil
+}
+
+func (m *MockBotAPI) ReopenGeneralTopic(chat *tele.Chat) error {
+	return nil
+}
+
+func (m *MockBotAPI) ReopenTopic(chat *tele.Chat, topic *tele.Topic) error {
+	return nil
+}
+
+func (m *MockBotAPI) ReplaceStickerInSet(of tele.Recipient, stickerSet, oldSticker string, sticker tele.InputSticker) (bool, error) {
+	return false, nil
+}
+
+func (m *MockBotAPI) Reply(to *tele.Message, what interface{}, opts ...interface{}) (*tele.Message, error) {
+	text, ok := what.(string)
+	if !ok {
+		return nil, errors.New("expected what of type string")
+	}
+
+	m.response.Text = text
+	m.response.Type = ResponseTypeReply
+	m.response.SendOptions = extractOptions(opts)
+
+	return nil, nil
+}
+
+func (m *MockBotAPI) Respond(c *tele.Callback, resp ...*tele.CallbackResponse) error {
+	return nil
+}
+
+func (m *MockBotAPI) Restrict(chat *tele.Chat, member *tele.ChatMember) error {
+	return nil
+}
+
+func (m *MockBotAPI) RevokeInviteLink(chat tele.Recipient, link string) (*tele.ChatInviteLink, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) Send(to tele.Recipient, what interface{}, opts ...interface{}) (*tele.Message, error) {
+	text, ok := what.(string)
+	if !ok {
+		return nil, errors.New("expected what of type string")
+	}
+
+	m.response.Text = text
+	m.response.Type = ResponseTypeSend
+	m.response.SendOptions = extractOptions(opts)
+
+	return nil, nil
+}
+
+func (m *MockBotAPI) SendAlbum(to tele.Recipient, a tele.Album, opts ...interface{}) ([]tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) SendPaid(to tele.Recipient, stars int, a tele.PaidAlbum, opts ...interface{}) (*tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) SetAdminTitle(chat *tele.Chat, user *tele.User, title string) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetCommands(opts ...interface{}) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetCustomEmojiStickerSetThumb(name, id string) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetDefaultRights(rights tele.Rights, forChannels bool) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetGameScore(user tele.Recipient, msg tele.Editable, score tele.GameHighScore) (*tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) SetGroupDescription(chat *tele.Chat, description string) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetGroupPermissions(chat *tele.Chat, perms tele.Rights) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetGroupStickerSet(chat *tele.Chat, setName string) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetGroupTitle(chat *tele.Chat, title string) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetMenuButton(chat *tele.User, mb interface{}) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetMyDescription(desc, language string) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetMyName(name, language string) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetMyShortDescription(desc, language string) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetStickerEmojis(sticker string, emojis []string) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetStickerKeywords(sticker string, keywords []string) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetStickerMaskPosition(sticker string, mask tele.MaskPosition) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetStickerPosition(sticker string, position int) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetStickerSetThumb(of tele.Recipient, set *tele.StickerSet) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetStickerSetTitle(s tele.StickerSet) error {
+	return nil
+}
+
+func (m *MockBotAPI) SetWebhook(w *tele.Webhook) error {
+	return nil
+}
+
+func (m *MockBotAPI) Ship(query *tele.ShippingQuery, what ...interface{}) error {
+	return nil
+}
+
+func (m *MockBotAPI) StarTransactions(offset, limit int) ([]tele.StarTransaction, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) StickerSet(name string) (*tele.StickerSet, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) StopLiveLocation(msg tele.Editable, opts ...interface{}) (*tele.Message, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) StopPoll(msg tele.Editable, opts ...interface{}) (*tele.Poll, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) TopicIconStickers() ([]tele.Sticker, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) Unban(chat *tele.Chat, user *tele.User, forBanned ...bool) error {
+	return nil
+}
+
+func (m *MockBotAPI) UnbanSenderChat(chat *tele.Chat, sender tele.Recipient) error {
+	return nil
+}
+
+func (m *MockBotAPI) UnhideGeneralTopic(chat *tele.Chat) error {
+	return nil
+}
+
+func (m *MockBotAPI) Unpin(chat tele.Recipient, messageID ...int) error {
+	return nil
+}
+
+func (m *MockBotAPI) UnpinAll(chat tele.Recipient) error {
+	return nil
+}
+
+func (m *MockBotAPI) UnpinAllGeneralTopicMessages(chat *tele.Chat) error {
+	return nil
+}
+
+func (m *MockBotAPI) UnpinAllTopicMessages(chat *tele.Chat, topic *tele.Topic) error {
+	return nil
+}
+
+func (m *MockBotAPI) UploadSticker(to tele.Recipient, format tele.StickerSetFormat, f tele.File) (*tele.File, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) UserBoosts(chat, user tele.Recipient) ([]tele.Boost, error) {
+	return nil, nil
+}
+
+func (m *MockBotAPI) Webhook() (*tele.Webhook, error) {
+	return nil, nil
+}

--- a/mocks/context_mock.go
+++ b/mocks/context_mock.go
@@ -16,6 +16,14 @@ type MockStorage struct {
 	m *sync.Mutex
 }
 
+func NewMockStorage() *MockStorage {
+	ms := new(MockStorage)
+	ms.s = make(map[string]any)
+	ms.m = new(sync.Mutex)
+
+	return ms
+}
+
 func (s *MockStorage) Set(key string, val any) {
 	s.m.Lock()
 	s.s[key] = val

--- a/mocks/context_mock.go
+++ b/mocks/context_mock.go
@@ -165,7 +165,7 @@ func NewMockContext(bot tele.API, update tele.Update, storage *MockStorage) *Moc
 // Methods bellow the line are for testing
 // --------------------------------------------------------------------
 
-func (c *MockContext) IsResponseType(responseType int) bool {
+func (c *MockContext) IsResponseTypeEqualsTo(responseType int) bool {
 	return responseType == c.response.Type
 }
 

--- a/mocks/context_mock.go
+++ b/mocks/context_mock.go
@@ -169,6 +169,11 @@ func (c *MockContext) IsResponseTypeEqualsTo(responseType int) bool {
 	return responseType == c.response.Type
 }
 
+func (c *MockContext) IsResponseTextEqualsTo(text string) bool {
+	return text == c.response.Text
+}
+
+
 // Methods bellow the line are to satisfy the tele.Context interface
 // --------------------------------------------------------------------
 

--- a/mocks/context_mock.go
+++ b/mocks/context_mock.go
@@ -173,6 +173,25 @@ func (c *MockContext) IsResponseTextEqualsTo(text string) bool {
 	return text == c.response.Text
 }
 
+// Returns true if [ReplyMarkup] stored in context.response is the same to given kb.
+func (c *MockContext) IsResponseReplyMarkUpEqualsTo(kb *tele.ReplyMarkup) (bool, error) {
+
+	ogKbJson, err := json.Marshal(c.response.SendOptions.ReplyMarkup)
+	if err != nil {
+		return false, fmt.Errorf("IsResponseReplyMarkUpEqualsTo: couldn't marshal original ReplyMarkup: %w", err)
+	}
+
+	givenKbJson, err := json.Marshal(kb)
+	if err != nil {
+		return false, fmt.Errorf("IsResponseReplyMarkUpEqualsTo: couldn't marshal given ReplyMarkup: %w", err)
+	}
+
+	if !bytes.Equal(ogKbJson, givenKbJson) {
+		return false, nil
+	}
+
+	return true, nil
+}
 
 // Methods bellow the line are to satisfy the tele.Context interface
 // --------------------------------------------------------------------

--- a/mocks/context_mock.go
+++ b/mocks/context_mock.go
@@ -1,7 +1,10 @@
 package mocks
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"fmt"
 	"sync"
 	"time"
 

--- a/mocks/context_mock.go
+++ b/mocks/context_mock.go
@@ -1,167 +1,11 @@
 package mocks
 
 import (
-	"bytes"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"sync"
 	"time"
 
 	tele "gopkg.in/telebot.v4"
 )
-
-type MockStorage struct {
-	s map[string]any
-	m *sync.Mutex
-}
-
-func NewMockStorage() *MockStorage {
-	ms := new(MockStorage)
-	ms.s = make(map[string]any)
-	ms.m = new(sync.Mutex)
-
-	return ms
-}
-
-func (s *MockStorage) Set(key string, val any) {
-	s.m.Lock()
-	s.s[key] = val
-	s.m.Unlock()
-}
-
-func (s *MockStorage) Get(key string) any {
-	val, ok := s.s[key]
-	if !ok {
-		return nil
-	}
-
-	return val
-}
-
-// Clears current storage.
-func (s *MockStorage) ClearData() {
-	s.m.Lock()
-	clear(s.s)
-	s.m.Unlock()
-}
-
-// what was sent to a user
-type HandlerResponse struct {
-
-	// Text of a displayed message or Text field of [tele.tele.CallbackResponse].
-	Text string
-	// In which way message was sent (Send, Reply, Edit, EditOrReply, Respond).
-	// Supported options are defined as iota-constants.
-	Type int
-	// Which [SendOptions] were used with response.
-	SendOptions *tele.SendOptions
-}
-
-const (
-	// c is tele.Context
-	// if handler called c.Send()
-	ResponseTypeSend = iota
-	// if handler called c.Reply()
-	ResponseTypeReply
-	// if handler called c.Edit()
-	ResponseTypeEdit
-	// if handler called c.EditOrReply()
-	ResponseTypeEditOrReply
-	// if handler called c.EditOrSend()
-	ResponseTypeEditOrSend
-	// if handler responded to a callback query
-	ResponseTypeCallbackResponse
-	// if handler responded to a callback query with alert
-	ResponseTypeCallbackResponseWithAlert
-)
-
-func copyReplyMarkUp(r *tele.ReplyMarkup) *tele.ReplyMarkup {
-	cp := *r
-
-	if len(r.ReplyKeyboard) > 0 {
-		cp.ReplyKeyboard = make([][]tele.ReplyButton, len(r.ReplyKeyboard))
-		for i, row := range r.ReplyKeyboard {
-			cp.ReplyKeyboard[i] = make([]tele.ReplyButton, len(row))
-			copy(cp.ReplyKeyboard[i], row)
-		}
-	}
-
-	if len(r.InlineKeyboard) > 0 {
-		cp.InlineKeyboard = make([][]tele.InlineButton, len(r.InlineKeyboard))
-		for i, row := range r.InlineKeyboard {
-			cp.InlineKeyboard[i] = make([]tele.InlineButton, len(row))
-			copy(cp.InlineKeyboard[i], row)
-		}
-	}
-
-	return &cp
-}
-
-func copySendOptions(og *tele.SendOptions) *tele.SendOptions {
-	cp := *og
-	if cp.ReplyMarkup != nil {
-		cp.ReplyMarkup = copyReplyMarkUp(cp.ReplyMarkup)
-	}
-	return &cp
-}
-
-func extractOptions(how []interface{}) *tele.SendOptions {
-	opts := &tele.SendOptions{
-		ParseMode: tele.ModeHTML,
-	}
-
-	for _, prop := range how {
-		switch opt := prop.(type) {
-		case *tele.SendOptions:
-			opts = copySendOptions(opt)
-		case *tele.ReplyMarkup:
-			if opt != nil {
-				opts.ReplyMarkup = copyReplyMarkUp(opt)
-			}
-		case *tele.ReplyParams:
-			opts.ReplyParams = opt
-		case *tele.Topic:
-			opts.ThreadID = opt.ThreadID
-		case tele.Option:
-			switch opt {
-			case tele.NoPreview:
-				opts.DisableWebPagePreview = true
-			case tele.Silent:
-				opts.DisableNotification = true
-			case tele.AllowWithoutReply:
-				opts.AllowWithoutReply = true
-			case tele.ForceReply:
-				if opts.ReplyMarkup == nil {
-					opts.ReplyMarkup = &tele.ReplyMarkup{}
-				}
-				opts.ReplyMarkup.ForceReply = true
-			case tele.OneTimeKeyboard:
-				if opts.ReplyMarkup == nil {
-					opts.ReplyMarkup = &tele.ReplyMarkup{}
-				}
-				opts.ReplyMarkup.OneTimeKeyboard = true
-			case tele.RemoveKeyboard:
-				if opts.ReplyMarkup == nil {
-					opts.ReplyMarkup = &tele.ReplyMarkup{}
-				}
-				opts.ReplyMarkup.RemoveKeyboard = true
-			case tele.Protected:
-				opts.Protected = true
-			default:
-				panic("telebot: unsupported flag-option")
-			}
-		case tele.ParseMode:
-			opts.ParseMode = opt
-		case tele.Entities:
-			opts.Entities = opt
-		default:
-			panic("telebot: unsupported send-option")
-		}
-	}
-
-	return opts
-}
 
 // MockContext mocks the original tele.Context for testing purpouses.
 type MockContext struct {
@@ -172,46 +16,16 @@ type MockContext struct {
 	response *HandlerResponse
 }
 
-func NewMockContext(bot tele.API, update tele.Update, storage *MockStorage) *MockContext {
+func NewMockContext(bot tele.API, update tele.Update, storage *MockStorage, resp *HandlerResponse) *MockContext {
 	return &MockContext{
-		bot:     bot,
-		update:  update,
-		storage: storage,
+		bot:      bot,
+		update:   update,
+		storage:  storage,
+		response: resp,
 	}
 }
 
-// Methods bellow the line are for testing
-// --------------------------------------------------------------------
-
-func (c *MockContext) IsResponseTypeEqualsTo(responseType int) bool {
-	return responseType == c.response.Type
-}
-
-func (c *MockContext) IsResponseTextEqualsTo(text string) bool {
-	return text == c.response.Text
-}
-
-// Returns true if [ReplyMarkup] stored in context.response is the same to given kb.
-func (c *MockContext) IsResponseReplyMarkUpEqualsTo(kb *tele.ReplyMarkup) (bool, error) {
-
-	ogKbJson, err := json.Marshal(c.response.SendOptions.ReplyMarkup)
-	if err != nil {
-		return false, fmt.Errorf("IsResponseReplyMarkUpEqualsTo: couldn't marshal original ReplyMarkup: %w", err)
-	}
-
-	givenKbJson, err := json.Marshal(kb)
-	if err != nil {
-		return false, fmt.Errorf("IsResponseReplyMarkUpEqualsTo: couldn't marshal given ReplyMarkup: %w", err)
-	}
-
-	if !bytes.Equal(ogKbJson, givenKbJson) {
-		return false, nil
-	}
-
-	return true, nil
-}
-
-// Methods bellow the line are to satisfy the tele.Context interface
+// Methods bellow the line are to satisfy the [tele.Context] interface
 // --------------------------------------------------------------------
 
 // Bot returns the bot instance.

--- a/mocks/context_mock.go
+++ b/mocks/context_mock.go
@@ -85,7 +85,7 @@ func (c *MockContext) Poll() *tele.Poll {
 }
 
 // // PollAnswer returns stored poll answer if such presented.
-func PollAnswer() *tele.PollAnswer {
+func (c *MockContext) PollAnswer() *tele.PollAnswer {
 	return &tele.PollAnswer{}
 }
 

--- a/mocks/context_mock.go
+++ b/mocks/context_mock.go
@@ -39,6 +39,13 @@ func (s *MockStorage) Get(key string) any {
 	return val
 }
 
+// Clears current storage.
+func (s *MockStorage) ClearData() {
+	s.m.Lock()
+	clear(s.s)
+	s.m.Unlock()
+}
+
 // what was sent to a user
 type HandlerResponse struct {
 

--- a/mocks/context_mock.go
+++ b/mocks/context_mock.go
@@ -166,7 +166,7 @@ func NewMockContext(bot tele.API, update tele.Update, storage *MockStorage) *Moc
 // --------------------------------------------------------------------
 
 func (c *MockContext) IsResponseType(responseType int) bool {
-	return responseType != c.response.Type
+	return responseType == c.response.Type
 }
 
 // Methods bellow the line are to satisfy the tele.Context interface

--- a/mocks/context_mock.go
+++ b/mocks/context_mock.go
@@ -1,0 +1,482 @@
+package mocks
+
+import (
+	"errors"
+	"sync"
+	"time"
+
+	tele "gopkg.in/telebot.v4"
+)
+
+type MockStorage struct {
+	s map[string]any
+	m *sync.Mutex
+}
+
+func (s *MockStorage) Set(key string, val any) {
+	s.m.Lock()
+	s.s[key] = val
+	s.m.Unlock()
+}
+
+func (s *MockStorage) Get(key string) any {
+	val, ok := s.s[key]
+	if !ok {
+		return nil
+	}
+
+	return val
+}
+
+// what was sent to a user
+type HandlerResponse struct {
+
+	// Text of a displayed message or Text field of [tele.tele.CallbackResponse].
+	Text string
+	// In which way message was sent (Send, Reply, Edit, EditOrReply, Respond).
+	// Supported options are defined as iota-constants.
+	Type int
+	// Which [SendOptions] were used with response.
+	SendOptions *tele.SendOptions
+}
+
+const (
+	// c is tele.Context
+	// if handler called c.Send()
+	ResponseTypeSend = iota
+	// if handler called c.Reply()
+	ResponseTypeReply
+	// if handler called c.Edit()
+	ResponseTypeEdit
+	// if handler called c.EditOrReply()
+	ResponseTypeEditOrReply
+	// if handler called c.EditOrSend()
+	ResponseTypeEditOrSend
+	// if handler responded to a callback query
+	ResponseTypeCallbackResponse
+	// if handler responded to a callback query with alert
+	ResponseTypeCallbackResponseWithAlert
+)
+
+func copyReplyMarkUp(r *tele.ReplyMarkup) *tele.ReplyMarkup {
+	cp := *r
+
+	if len(r.ReplyKeyboard) > 0 {
+		cp.ReplyKeyboard = make([][]tele.ReplyButton, len(r.ReplyKeyboard))
+		for i, row := range r.ReplyKeyboard {
+			cp.ReplyKeyboard[i] = make([]tele.ReplyButton, len(row))
+			copy(cp.ReplyKeyboard[i], row)
+		}
+	}
+
+	if len(r.InlineKeyboard) > 0 {
+		cp.InlineKeyboard = make([][]tele.InlineButton, len(r.InlineKeyboard))
+		for i, row := range r.InlineKeyboard {
+			cp.InlineKeyboard[i] = make([]tele.InlineButton, len(row))
+			copy(cp.InlineKeyboard[i], row)
+		}
+	}
+
+	return &cp
+}
+
+func copySendOptions(og *tele.SendOptions) *tele.SendOptions {
+	cp := *og
+	if cp.ReplyMarkup != nil {
+		cp.ReplyMarkup = copyReplyMarkUp(cp.ReplyMarkup)
+	}
+	return &cp
+}
+
+func extractOptions(how []interface{}) *tele.SendOptions {
+	opts := &tele.SendOptions{
+		ParseMode: tele.ModeHTML,
+	}
+
+	for _, prop := range how {
+		switch opt := prop.(type) {
+		case *tele.SendOptions:
+			opts = copySendOptions(opt)
+		case *tele.ReplyMarkup:
+			if opt != nil {
+				opts.ReplyMarkup = copyReplyMarkUp(opt)
+			}
+		case *tele.ReplyParams:
+			opts.ReplyParams = opt
+		case *tele.Topic:
+			opts.ThreadID = opt.ThreadID
+		case tele.Option:
+			switch opt {
+			case tele.NoPreview:
+				opts.DisableWebPagePreview = true
+			case tele.Silent:
+				opts.DisableNotification = true
+			case tele.AllowWithoutReply:
+				opts.AllowWithoutReply = true
+			case tele.ForceReply:
+				if opts.ReplyMarkup == nil {
+					opts.ReplyMarkup = &tele.ReplyMarkup{}
+				}
+				opts.ReplyMarkup.ForceReply = true
+			case tele.OneTimeKeyboard:
+				if opts.ReplyMarkup == nil {
+					opts.ReplyMarkup = &tele.ReplyMarkup{}
+				}
+				opts.ReplyMarkup.OneTimeKeyboard = true
+			case tele.RemoveKeyboard:
+				if opts.ReplyMarkup == nil {
+					opts.ReplyMarkup = &tele.ReplyMarkup{}
+				}
+				opts.ReplyMarkup.RemoveKeyboard = true
+			case tele.Protected:
+				opts.Protected = true
+			default:
+				panic("telebot: unsupported flag-option")
+			}
+		case tele.ParseMode:
+			opts.ParseMode = opt
+		case tele.Entities:
+			opts.Entities = opt
+		default:
+			panic("telebot: unsupported send-option")
+		}
+	}
+
+	return opts
+}
+
+// MockContext mocks the original tele.Context for testing purpouses.
+type MockContext struct {
+	bot     tele.API
+	update  tele.Update
+	storage *MockStorage
+
+	response *HandlerResponse
+}
+
+func NewMockContext(bot tele.API, update tele.Update, storage *MockStorage) *MockContext {
+	return &MockContext{
+		bot:     bot,
+		update:  update,
+		storage: storage,
+	}
+}
+
+// Methods bellow the line are for testing
+// --------------------------------------------------------------------
+
+func (c *MockContext) IsResponseType(responseType int) bool {
+	return responseType != c.response.Type
+}
+
+// Methods bellow the line are to satisfy the tele.Context interface
+// --------------------------------------------------------------------
+
+// Bot returns the bot instance.
+func (c *MockContext) Bot() tele.API {
+	return c.bot
+}
+
+// // Update returns the original update.
+func (c *MockContext) Update() tele.Update {
+	return c.update
+}
+
+// // Message returns stored message if such presented.
+func (c *MockContext) Message() *tele.Message {
+	if c.update.Message != nil {
+		return c.update.Message
+	}
+	return nil
+}
+
+// // Callback returns stored callback if such presented.
+func (c *MockContext) Callback() *tele.Callback {
+	if c.update.Callback != nil {
+		return c.update.Callback
+	}
+	return nil
+}
+
+// // Query returns stored query if such presented.
+func (c *MockContext) Query() *tele.Query {
+	return &tele.Query{}
+}
+
+// // InlineResult returns stored inline result if such presented.
+func (c *MockContext) InlineResult() *tele.InlineResult {
+	return &tele.InlineResult{}
+}
+
+// // ShippingQuery returns stored shipping query if such presented.
+func (c *MockContext) ShippingQuery() *tele.ShippingQuery {
+	return &tele.ShippingQuery{}
+}
+
+// // PreCheckoutQuery returns stored pre checkout query if such presented.
+func (c *MockContext) PreCheckoutQuery() *tele.PreCheckoutQuery {
+	return &tele.PreCheckoutQuery{}
+}
+
+// // Payment returns payment instance.
+func (c *MockContext) Payment() *tele.Payment {
+	return &tele.Payment{}
+}
+
+// // Poll returns stored poll if such presented.
+func (c *MockContext) Poll() *tele.Poll {
+	return &tele.Poll{}
+}
+
+// // PollAnswer returns stored poll answer if such presented.
+func PollAnswer() *tele.PollAnswer {
+	return &tele.PollAnswer{}
+}
+
+// // ChatMember returns chat member changes.
+func (c *MockContext) ChatMember() *tele.ChatMemberUpdate {
+	return &tele.ChatMemberUpdate{}
+}
+
+// // ChatJoinRequest returns the chat join request.
+func (c *MockContext) ChatJoinRequest() *tele.ChatJoinRequest {
+	return &tele.ChatJoinRequest{}
+}
+
+// // Migration returns both migration from and to chat IDs.
+func (c *MockContext) Migration() (int64, int64) {
+	return 0, 0
+}
+
+// // Topic returns the topic changes.
+func (c *MockContext) Topic() *tele.Topic {
+	return &tele.Topic{}
+}
+
+// // Boost returns the boost instance.
+func (c *MockContext) Boost() *tele.BoostUpdated {
+	return &tele.BoostUpdated{}
+}
+
+// // BoostRemoved returns the boost removed from a chat instance.
+func (c *MockContext) BoostRemoved() *tele.BoostRemoved {
+	return &tele.BoostRemoved{}
+}
+
+// // Sender returns the current recipient, depending on the context type.
+// // Returns nil if user is not presented.
+func (c *MockContext) Sender() *tele.User {
+	return &tele.User{}
+}
+
+// // Chat returns the current chat, depending on the context type.
+// // Returns nil if chat is not presented.
+func (c *MockContext) Chat() *tele.Chat {
+	return &tele.Chat{}
+}
+
+// // Recipient combines both Sender and Chat functions. If there is no user
+// // the chat will be returned. The native context cannot be without sender,
+// // but it is useful in the case when the context created intentionally
+// // by the NewContext constructor and have only Chat field inside.
+func (c *MockContext) Recipient() tele.Recipient {
+	return &tele.User{}
+}
+
+// // Text returns the message text, depending on the context type.
+// // In the case when no related data presented, returns an empty string.
+func (c *MockContext) Text() string {
+	if c.update.Message != nil {
+		return c.update.Message.Text
+	}
+	return ""
+}
+
+// // Entities returns the message entities, whether it's media caption's or the text's.
+// // In the case when no entities presented, returns a nil.
+func (c *MockContext) Entities() tele.Entities {
+	return tele.Entities{}
+}
+
+// // Data returns the current data, depending on the context type.
+// // If the context contains command, returns its arguments string.
+// // If the context contains payment, returns its payload.
+// // In the case when no related data presented, returns an empty string.
+func (c *MockContext) Data() string {
+	return ""
+}
+
+// // Args returns a raw slice of command or callback arguments as strings.
+// // The message arguments split by space, while the callback's ones by a "|" symbol.
+func (c *MockContext) Args() []string {
+	return []string{}
+}
+
+// // Send sends a message to the current recipient.
+// // See Send from bot.go.
+func (c *MockContext) Send(what interface{}, opts ...interface{}) error {
+	text, ok := what.(string)
+	if !ok {
+		return errors.New("expected what of type string")
+	}
+
+	c.response.Text = text
+	c.response.Type = ResponseTypeSend
+	c.response.SendOptions = extractOptions(opts)
+
+	return nil
+}
+
+// // SendAlbum sends an album to the current recipient.
+// // See SendAlbum from bot.go.
+func (c *MockContext) SendAlbum(a tele.Album, opts ...interface{}) error {
+	return nil
+}
+
+// // Reply replies to the current message.
+// // See Reply from bot.go.
+func (c *MockContext) Reply(what interface{}, opts ...interface{}) error {
+	text, ok := what.(string)
+	if !ok {
+		return errors.New("expected what of type string")
+	}
+
+	c.response.Text = text
+	c.response.Type = ResponseTypeReply
+	c.response.SendOptions = extractOptions(opts)
+
+	return nil
+}
+
+// // Forward forwards the given message to the current recipient.
+// // See Forward from bot.go.
+func (c *MockContext) Forward(msg tele.Editable, opts ...interface{}) error {
+	return nil
+}
+
+// // ForwardTo forwards the current message to the given recipient.
+// // See Forward from bot.go
+func (c *MockContext) ForwardTo(to tele.Recipient, opts ...interface{}) error {
+	return nil
+}
+
+// // Edit edits the current message.
+// // See Edit from bot.go.
+func (c *MockContext) Edit(what interface{}, opts ...interface{}) error {
+	text, ok := what.(string)
+	if !ok {
+		return errors.New("expected what of type string")
+	}
+
+	c.response.Text = text
+	c.response.Type = ResponseTypeEdit
+	c.response.SendOptions = extractOptions(opts)
+
+	return nil
+}
+
+// // EditCaption edits the caption of the current message.
+// // See EditCaption from bot.go.
+func (c *MockContext) EditCaption(caption string, opts ...interface{}) error {
+	return nil
+}
+
+// // EditOrSend edits the current message if the update is callback,
+// // otherwise the content is sent to the chat as a separate message.
+func (c *MockContext) EditOrSend(what interface{}, opts ...interface{}) error {
+	text, ok := what.(string)
+	if !ok {
+		return errors.New("expected what of type string")
+	}
+
+	c.response.Text = text
+	c.response.Type = ResponseTypeEditOrSend
+	c.response.SendOptions = extractOptions(opts)
+
+	return nil
+}
+
+// // EditOrReply edits the current message if the update is callback,
+// // otherwise the content is replied as a separate message.
+func (c *MockContext) EditOrReply(what interface{}, opts ...interface{}) error {
+	text, ok := what.(string)
+	if !ok {
+		return errors.New("expected what of type string")
+	}
+
+	c.response.Text = text
+	c.response.Type = ResponseTypeEditOrReply
+	c.response.SendOptions = extractOptions(opts)
+
+	return nil
+}
+
+// // Delete removes the current message.
+// // See Delete from bot.go.
+func (c *MockContext) Delete() error {
+	return nil
+}
+
+// // DeleteAfter waits for the duration to elapse and then removes the
+// // message. It handles an error automatically using b.OnError callback.
+// // It returns a Timer that can be used to cancel the call using its Stop method.
+func (c *MockContext) DeleteAfter(d time.Duration) *time.Timer {
+	return time.NewTimer(d)
+}
+
+// // Notify updates the chat action for the current recipient.
+// // See Notify from bot.go.
+func (c *MockContext) Notify(action tele.ChatAction) error {
+	return nil
+}
+
+// // Ship replies to the current shipping query.
+// // See Ship from bot.go.
+func (c *MockContext) Ship(what ...interface{}) error {
+	return nil
+}
+
+// // Accept finalizes the current deal.
+// // See Accept from bot.go.
+func (c *MockContext) Accept(errorMessage ...string) error {
+	return nil
+}
+
+// // Answer sends a response to the current inline query.
+// // See Answer from bot.go.
+func (c *MockContext) Answer(resp *tele.QueryResponse) error {
+	return nil
+}
+
+// // Respond sends a response for the current callback query.
+// // See Respond from bot.go.
+func (c *MockContext) Respond(resp ...*tele.CallbackResponse) error {
+	c.response.Text = resp[0].Text
+	if resp[0].ShowAlert {
+		c.response.Type = ResponseTypeCallbackResponseWithAlert
+	} else {
+		c.response.Type = ResponseTypeCallbackResponse
+	}
+
+	return nil
+}
+
+// // RespondText sends a popup response for the current callback query.
+func (c *MockContext) RespondText(text string) error {
+	return nil
+}
+
+// // RespondAlert sends an alert response for the current callback query.
+func (c *MockContext) RespondAlert(text string) error {
+	return nil
+}
+
+// // Get retrieves data from the context.
+func (c *MockContext) Get(key string) interface{} {
+	return c.storage.Get(key)
+}
+
+// // Set saves data in the context.
+func (c *MockContext) Set(key string, val interface{}) {
+	c.storage.Set(key, val)
+}

--- a/mocks/fsmContext_mock.go
+++ b/mocks/fsmContext_mock.go
@@ -41,6 +41,11 @@ func NewMockFsmContext(s *MockStorage, defaultState fsm.State) *MockFsmContext {
 // Methods bellow the line are for testing
 // --------------------------------------------------------------------
 
+// Returns true, if state is the as what's stored in MockFsmContext now.
+func (f *MockFsmContext) IsStateEqualsTo(state fsm.State) bool {
+	return f.state == state
+}
+
 // Methods bellow the line are to satisfy the [fsm.Context] interface
 // --------------------------------------------------------------------
 

--- a/mocks/fsmContext_mock.go
+++ b/mocks/fsmContext_mock.go
@@ -1,0 +1,110 @@
+package mocks
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/vitaliy-ukiru/fsm-telebot/v2"
+)
+
+// type Context interface {
+// 	// State returns current state for sender.
+// 	State(ctx context.Context) (State, error)
+
+// 	// SetState state for sender.
+// 	SetState(ctx context.Context, state State) error
+
+// 	// Finish state for sender and deletes data if arg provided.
+// 	Finish(ctx context.Context, deleteData bool) error
+
+// 	// Update data in storage. When data argument is nil it must
+// 	// delete this item.
+// 	Update(ctx context.Context, key string, data any) error
+
+// 	// Data gets from storage and save it into `to` argument.
+// 	// Destination argument must be a valid pointer.
+// 	Data(ctx context.Context, key string, to any) error
+// }
+
+type MockFsmContext struct {
+	storage      *MockStorage
+	state        fsm.State
+	defaultState fsm.State
+}
+
+func NewMockFsmContext(s *MockStorage, defaultState fsm.State) *MockFsmContext {
+	return &MockFsmContext{storage: s, defaultState: defaultState}
+}
+
+// Methods bellow the line are for testing
+// --------------------------------------------------------------------
+
+// Methods bellow the line are to satisfy the [fsm.Context] interface
+// --------------------------------------------------------------------
+
+func (f *MockFsmContext) State(ctx context.Context) (fsm.State, error) {
+	return f.state, nil
+}
+
+func (f *MockFsmContext) SetState(ctx context.Context, state fsm.State) error {
+	f.state = state
+	return nil
+}
+
+func (f *MockFsmContext) Finish(ctx context.Context, deleteData bool) error {
+	f.state = f.defaultState
+	if deleteData {
+		f.storage.ClearData()
+	}
+
+	return nil
+}
+
+func (f *MockFsmContext) Update(ctx context.Context, key string, data any) error {
+	f.storage.Set(key, data)
+	return nil
+}
+
+func (f *MockFsmContext) Data(ctx context.Context, key string, to any) error {
+	v := f.storage.Get(key)
+
+	destValue := reflect.ValueOf(to)
+	if destValue.Kind() != reflect.Ptr {
+		return ErrNotPointer
+	}
+	if destValue.IsNil() || !destValue.IsValid() {
+		return ErrInvalidValue
+	}
+
+	destElem := destValue.Elem()
+	if !destElem.IsValid() {
+		return ErrNotPointer
+	}
+
+	destType := destElem.Type()
+
+	vType := reflect.TypeOf(v)
+	if !vType.AssignableTo(destType) {
+		return &ErrWrongTypeAssign{
+			Expect: vType,
+			Got:    destType,
+		}
+	}
+	destElem.Set(reflect.ValueOf(v))
+	return nil
+}
+
+// from original [repo](https://github.com/vitaliy-ukiru/fsm-telebot/blob/v2.x/pkg/storage/memory/errors.go)
+var ErrNotPointer = errors.New("fsm/storage/memory: dest argument must be pointer")
+var ErrInvalidValue = errors.New("fsm/storage/memory: dest value is nil or invalid")
+
+type ErrWrongTypeAssign struct {
+	Expect reflect.Type
+	Got    reflect.Type
+}
+
+func (e ErrWrongTypeAssign) Error() string {
+	return fmt.Sprintf("fsm/storage: wrong types, can't assign %s to %s", e.Expect, e.Got)
+}

--- a/mocks/util.go
+++ b/mocks/util.go
@@ -85,6 +85,8 @@ func NewMockStorage() *MockStorage {
 	return ms
 }
 
+// Sets storage with (key, val). If val is nil and map already has a value with given key, then key is deleated.
+// In case if val is nil and no value with that key, than it's ignored.
 func (s *MockStorage) Set(key string, val any) {
 	if val == nil {
 		s.m.RLock()
@@ -103,6 +105,7 @@ func (s *MockStorage) Set(key string, val any) {
 	s.m.Unlock()
 }
 
+// Returns a value for given key. If there is no value for that key, then nil is returned.
 func (s *MockStorage) Get(key string) any {
 	s.m.RLock()
 	val, ok := s.s[key]

--- a/mocks/util.go
+++ b/mocks/util.go
@@ -86,6 +86,18 @@ func NewMockStorage() *MockStorage {
 }
 
 func (s *MockStorage) Set(key string, val any) {
+	if val == nil {
+		s.m.RLock()
+		_, ok := s.s[key]
+		s.m.RUnlock()
+		if ok {
+			s.m.Lock()
+			delete(s.s, key)
+			s.m.Unlock()
+		}
+		return
+	}
+
 	s.m.Lock()
 	s.s[key] = val
 	s.m.Unlock()

--- a/mocks/util.go
+++ b/mocks/util.go
@@ -1,0 +1,195 @@
+package mocks
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+
+	tele "gopkg.in/telebot.v4"
+)
+
+// what was sent to a user
+type HandlerResponse struct {
+
+	// Text of a displayed message or Text field of [tele.tele.CallbackResponse].
+	Text string
+	// In which way message was sent (Send, Reply, Edit, EditOrReply, Respond).
+	// Supported options are defined as iota-constants.
+	Type int
+	// Which [SendOptions] were used with response.
+	SendOptions *tele.SendOptions
+}
+
+const (
+	// c is tele.Context
+	// if handler called c.Send()
+	ResponseTypeSend = iota
+	// if handler called c.Reply()
+	ResponseTypeReply
+	// if handler called c.Edit()
+	ResponseTypeEdit
+	// if handler called c.EditOrReply()
+	ResponseTypeEditOrReply
+	// if handler called c.EditOrSend()
+	ResponseTypeEditOrSend
+	// if handler responded to a callback query
+	ResponseTypeCallbackResponse
+	// if handler responded to a callback query with alert
+	ResponseTypeCallbackResponseWithAlert
+)
+
+func (r *HandlerResponse) IsResponseTypeEqualsTo(responseType int) bool {
+	return responseType == r.Type
+}
+
+func (r *HandlerResponse) IsResponseTextEqualsTo(text string) bool {
+	return text == r.Text
+}
+
+// Returns true if [ReplyMarkup] stored in context.response is the same to given kb.
+func (r *HandlerResponse) IsResponseReplyMarkUpEqualsTo(kb *tele.ReplyMarkup) (bool, error) {
+
+	if r.SendOptions == nil {
+		return false, errors.New("SendOption is nil")
+	}
+
+	ogKbJson, err := json.Marshal(r.SendOptions.ReplyMarkup)
+	if err != nil {
+		return false, fmt.Errorf("IsResponseReplyMarkUpEqualsTo: couldn't marshal original ReplyMarkup: %w", err)
+	}
+
+	givenKbJson, err := json.Marshal(kb)
+	if err != nil {
+		return false, fmt.Errorf("IsResponseReplyMarkUpEqualsTo: couldn't marshal given ReplyMarkup: %w", err)
+	}
+
+	if !bytes.Equal(ogKbJson, givenKbJson) {
+		return false, nil
+	}
+
+	return true, nil
+}
+
+type MockStorage struct {
+	s map[string]any
+	m *sync.Mutex
+}
+
+func NewMockStorage() *MockStorage {
+	ms := new(MockStorage)
+	ms.s = make(map[string]any)
+	ms.m = new(sync.Mutex)
+
+	return ms
+}
+
+func (s *MockStorage) Set(key string, val any) {
+	s.m.Lock()
+	s.s[key] = val
+	s.m.Unlock()
+}
+
+func (s *MockStorage) Get(key string) any {
+	val, ok := s.s[key]
+	if !ok {
+		return nil
+	}
+
+	return val
+}
+
+// Clears current storage.
+func (s *MockStorage) ClearData() {
+	s.m.Lock()
+	clear(s.s)
+	s.m.Unlock()
+}
+
+func copyReplyMarkUp(r *tele.ReplyMarkup) *tele.ReplyMarkup {
+	cp := *r
+
+	if len(r.ReplyKeyboard) > 0 {
+		cp.ReplyKeyboard = make([][]tele.ReplyButton, len(r.ReplyKeyboard))
+		for i, row := range r.ReplyKeyboard {
+			cp.ReplyKeyboard[i] = make([]tele.ReplyButton, len(row))
+			copy(cp.ReplyKeyboard[i], row)
+		}
+	}
+
+	if len(r.InlineKeyboard) > 0 {
+		cp.InlineKeyboard = make([][]tele.InlineButton, len(r.InlineKeyboard))
+		for i, row := range r.InlineKeyboard {
+			cp.InlineKeyboard[i] = make([]tele.InlineButton, len(row))
+			copy(cp.InlineKeyboard[i], row)
+		}
+	}
+
+	return &cp
+}
+
+func copySendOptions(og *tele.SendOptions) *tele.SendOptions {
+	cp := *og
+	if cp.ReplyMarkup != nil {
+		cp.ReplyMarkup = copyReplyMarkUp(cp.ReplyMarkup)
+	}
+	return &cp
+}
+
+func extractOptions(how []interface{}) *tele.SendOptions {
+	opts := &tele.SendOptions{
+		ParseMode: tele.ModeHTML,
+	}
+
+	for _, prop := range how {
+		switch opt := prop.(type) {
+		case *tele.SendOptions:
+			opts = copySendOptions(opt)
+		case *tele.ReplyMarkup:
+			if opt != nil {
+				opts.ReplyMarkup = copyReplyMarkUp(opt)
+			}
+		case *tele.ReplyParams:
+			opts.ReplyParams = opt
+		case *tele.Topic:
+			opts.ThreadID = opt.ThreadID
+		case tele.Option:
+			switch opt {
+			case tele.NoPreview:
+				opts.DisableWebPagePreview = true
+			case tele.Silent:
+				opts.DisableNotification = true
+			case tele.AllowWithoutReply:
+				opts.AllowWithoutReply = true
+			case tele.ForceReply:
+				if opts.ReplyMarkup == nil {
+					opts.ReplyMarkup = &tele.ReplyMarkup{}
+				}
+				opts.ReplyMarkup.ForceReply = true
+			case tele.OneTimeKeyboard:
+				if opts.ReplyMarkup == nil {
+					opts.ReplyMarkup = &tele.ReplyMarkup{}
+				}
+				opts.ReplyMarkup.OneTimeKeyboard = true
+			case tele.RemoveKeyboard:
+				if opts.ReplyMarkup == nil {
+					opts.ReplyMarkup = &tele.ReplyMarkup{}
+				}
+				opts.ReplyMarkup.RemoveKeyboard = true
+			case tele.Protected:
+				opts.Protected = true
+			default:
+				panic("telebot: unsupported flag-option")
+			}
+		case tele.ParseMode:
+			opts.ParseMode = opt
+		case tele.Entities:
+			opts.Entities = opt
+		default:
+			panic("telebot: unsupported send-option")
+		}
+	}
+
+	return opts
+}

--- a/mocks/util.go
+++ b/mocks/util.go
@@ -74,13 +74,13 @@ func (r *HandlerResponse) IsResponseReplyMarkUpEqualsTo(kb *tele.ReplyMarkup) (b
 
 type MockStorage struct {
 	s map[string]any
-	m *sync.Mutex
+	m *sync.RWMutex
 }
 
 func NewMockStorage() *MockStorage {
 	ms := new(MockStorage)
 	ms.s = make(map[string]any)
-	ms.m = new(sync.Mutex)
+	ms.m = new(sync.RWMutex)
 
 	return ms
 }
@@ -92,7 +92,9 @@ func (s *MockStorage) Set(key string, val any) {
 }
 
 func (s *MockStorage) Get(key string) any {
+	s.m.RLock()
 	val, ok := s.s[key]
+	s.m.RUnlock()
 	if !ok {
 		return nil
 	}


### PR DESCRIPTION
## Testing
Implementation of new tools for message-handlers testing. The list of implemented is:

- MockBotAPI &mdash; implements [tele.API](https://github.com/go-telebot/telebot/blob/v4/api.go) interface with methods `Send`, `Edit` and `Reply` implemented for testing.
- MockContext &mdash; implements [tele.Context](https://github.com/go-telebot/telebot/blob/v4/context.go) interface  with `Send`, `Edit`, `Reply`, `EditOrSend`, `EditOrReply` and `Respond` implemented for testing.
- MockFsmContext &mdash; implements [fsm.Context](https://github.com/vitaliy-ukiru/fsm-telebot) interface.
- MockStorage &mdash; simple storage for [tele.Context](https://github.com/go-telebot/telebot/blob/v4/context.go) and [fsm.Context](https://github.com/vitaliy-ukiru/fsm-telebot). 
- HandlerResponse &mdash; struct for testing handlers responses: what and how did they send it.
- Helper functions for result assertion: `assertHandlerError`, `assertHandlerResponse`, `assertState` and `assertStorage`.

## Blog Update: Testing
- New post about my testing road in this app: how I approached testing, what was done, what problems I encountered.
- Typo fixes :p